### PR TITLE
Updating the name of National Instruments design system

### DIFF
--- a/src/data/data.JSON
+++ b/src/data/data.JSON
@@ -4330,7 +4330,7 @@
       "label": "company"
     },
     "system": {
-      "data": "Design System for LabVIEW NXG",
+      "data": "Fuse",
       "url": "https://ni.github.io/design-system/",
       "label": "system",
       "$addedAt": "201801171757"
@@ -4400,7 +4400,7 @@
       "label": "color palette"
     },
     "colorNaming": {
-      "data": "branded and natural (e.g.NIBlueBrush",
+      "data": "branded and natural (e.g.NIBlueBrush)",
       "label": "color naming"
     },
     "contrastAnalysis": {

--- a/src/data/systems/201801171757-national-instruments.json
+++ b/src/data/systems/201801171757-national-instruments.json
@@ -4,7 +4,7 @@
     "label": "company"
   },
   "system": {
-    "data": "Design System for LabVIEW NXG",
+    "data": "Fuse",
     "url": "https://ni.github.io/design-system/",
     "label": "system"
   },
@@ -73,7 +73,7 @@
     "label": "color palette"
   },
   "colorNaming": {
-    "data": "branded and natural (e.g.NIBlueBrush",
+    "data": "branded and natural (e.g.NIBlueBrush)",
     "label": "color naming"
   },
   "contrastAnalysis": {


### PR DESCRIPTION
The name of the National Instruments design system was recently changed to, "Fuse," so I updated the name. 
Also fixed a small typo for the color naming example.

Thank you for compiling this list, it is a great resource.