### PR TITLE
Remove link to Meetup's UI kit in Abstract

### DIFF
--- a/src/data/data.JSON
+++ b/src/data/data.JSON
@@ -8748,7 +8748,7 @@
       "label": "distribution"
     }
   },
-    {
+  {
     "company": {
       "data": "hubspot",
       "label": "company"
@@ -8968,7 +8968,7 @@
     },
     "uiKit": {
       "data": "Sketch",
-      "url": "https://share.goabstract.com/e1e2f321-fc7d-4db4-b8eb-4929b24a1a40",
+      "url": "",
       "label": "UI kit"
     },
     "brandGuidelines": {

--- a/src/data/systems/201802062318-meetup.json
+++ b/src/data/systems/201802062318-meetup.json
@@ -62,7 +62,7 @@
   },
   "uiKit": {
     "data": "Sketch",
-    "url": "https://share.goabstract.com/e1e2f321-fc7d-4db4-b8eb-4929b24a1a40",
+    "url": "",
     "label": "UI kit"
   },
   "brandGuidelines": {


### PR DESCRIPTION
We keep getting spammed by strangers requesting access to our Abstract project, so I'd like to remove this link. I'm open to suggestions to let other teams look at our Sketch UI kit, I just don't want my co-workers and I to keep getting these mysterious requests