### PR TITLE
Update Shopify Polaris design token data

### DIFF
--- a/src/data/systems/201801171804-shopify.json
+++ b/src/data/systems/201801171804-shopify.json
@@ -60,7 +60,11 @@
     "label": "CSS in JS"
   },
   "designTokens": {
-    "data": "no",
+    "data": [
+      "DSM"
+      "yaml",
+      "theo"
+    ],
     "label": "design tokens"
   },
   "bundleManager": {


### PR DESCRIPTION
Design tokens are now used in the Polaris design system (polaris.shopify.com, polaris-react, polaris-rails, and in production in a few other products). See https://github.com/Shopify/polaris-tokens for more information.