### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ managed the System Concepts Laboratory where, together with Alan Kay and others,
 Smalltalk-80 – an object-oriented, dynamically typed programming language that was meant to power
 "human-computer symbiosis".
 
-Needless to say, SmallTalk also pioneered many concepts important to all modern design systems.
+Needless to say, Smalltalk also pioneered many concepts important to all modern design systems.
 Objects in Smalltalk were easily transferable between applications and customizable. Smalltalk also
 served as the foundation of PARC's work on graphically based user interfaces (many GUI concepts have
 been developed by Adele Goldberg and her group!).


### PR DESCRIPTION
Under the Why Adele? section, Smalltalk is mentioned several times. In one of the mentions, it capitalizes both the 'S' and the 'T' like "SmallTalk" - but all other mentions only the 'S' is capitalized. Wanted to make it uniform.